### PR TITLE
Add simple Kanban lead management UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
-# test-codex-leads
+# Lead Management Application
+
+This repository contains a simple lead management interface with a Kanban board.
+Leads can be created, edited and moved between columns. The UI attempts to use
+Aceternity UI via CDN. Open `index.html` in a browser to get started.
+

--- a/index.html
+++ b/index.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Lead Manager</title>
+  <link rel="stylesheet" href="style.css">
+  <!-- Attempt to include Aceternity UI via CDN if available -->
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/aceternity-ui/dist/aceternity.min.css">
+</head>
+<body>
+  <h1>Lead Management (Kanban)</h1>
+  <div id="createLeadForm">
+    <input type="text" id="leadName" placeholder="Lead name">
+    <input type="text" id="leadEmail" placeholder="Email">
+    <input type="text" id="leadCompany" placeholder="Company">
+    <select id="leadColumn">
+      <option value="new">New</option>
+      <option value="contacted">Contacted</option>
+      <option value="client">Client</option>
+    </select>
+    <button id="addLead">Add Lead</button>
+  </div>
+  <div id="board">
+    <div class="column" data-status="new">
+      <h2>New</h2>
+      <div class="leadContainer" id="new"></div>
+    </div>
+    <div class="column" data-status="contacted">
+      <h2>Contacted</h2>
+      <div class="leadContainer" id="contacted"></div>
+    </div>
+    <div class="column" data-status="client">
+      <h2>Client</h2>
+      <div class="leadContainer" id="client"></div>
+    </div>
+  </div>
+
+  <!-- Modal for editing -->
+  <div id="modal" class="hidden">
+    <div class="modal-content">
+      <h3>Edit Lead</h3>
+      <input type="text" id="editName" placeholder="Lead name">
+      <input type="text" id="editEmail" placeholder="Email">
+      <input type="text" id="editCompany" placeholder="Company">
+      <select id="editColumn">
+        <option value="new">New</option>
+        <option value="contacted">Contacted</option>
+        <option value="client">Client</option>
+      </select>
+      <button id="saveLead">Save</button>
+      <button id="cancelEdit">Cancel</button>
+    </div>
+  </div>
+
+  <script src="script.js"></script>
+</body>
+</html>
+

--- a/script.js
+++ b/script.js
@@ -1,0 +1,88 @@
+const leads = [];
+let currentEditId = null;
+
+function createLeadElement(lead) {
+  const div = document.createElement('div');
+  div.className = 'lead';
+  div.draggable = true;
+  div.dataset.id = lead.id;
+  div.textContent = `${lead.name} (${lead.company})`;
+
+  div.addEventListener('click', () => openEditModal(lead.id));
+  div.addEventListener('dragstart', e => {
+    e.dataTransfer.setData('text/plain', lead.id);
+  });
+  return div;
+}
+
+function render() {
+  ['new', 'contacted', 'client'].forEach(status => {
+    const container = document.getElementById(status);
+    container.innerHTML = '';
+    leads.filter(l => l.status === status).forEach(lead => {
+      container.appendChild(createLeadElement(lead));
+    });
+  });
+}
+
+function addLead() {
+  const name = document.getElementById('leadName').value.trim();
+  const email = document.getElementById('leadEmail').value.trim();
+  const company = document.getElementById('leadCompany').value.trim();
+  const status = document.getElementById('leadColumn').value;
+  if (!name) return;
+  leads.push({ id: Date.now().toString(), name, email, company, status });
+  document.getElementById('leadName').value = '';
+  document.getElementById('leadEmail').value = '';
+  document.getElementById('leadCompany').value = '';
+  render();
+}
+
+function openEditModal(id) {
+  const lead = leads.find(l => l.id === id);
+  if (!lead) return;
+  currentEditId = id;
+  document.getElementById('editName').value = lead.name;
+  document.getElementById('editEmail').value = lead.email;
+  document.getElementById('editCompany').value = lead.company;
+  document.getElementById('editColumn').value = lead.status;
+  document.getElementById('modal').classList.remove('hidden');
+}
+
+function saveLead() {
+  const lead = leads.find(l => l.id === currentEditId);
+  if (!lead) return;
+  lead.name = document.getElementById('editName').value.trim();
+  lead.email = document.getElementById('editEmail').value.trim();
+  lead.company = document.getElementById('editCompany').value.trim();
+  lead.status = document.getElementById('editColumn').value;
+  document.getElementById('modal').classList.add('hidden');
+  render();
+}
+
+function setupDragAndDrop() {
+  document.querySelectorAll('.leadContainer').forEach(container => {
+    container.addEventListener('dragover', e => e.preventDefault());
+    container.addEventListener('drop', e => {
+      e.preventDefault();
+      const id = e.dataTransfer.getData('text/plain');
+      const lead = leads.find(l => l.id === id);
+      if (lead) {
+        lead.status = container.id;
+        render();
+      }
+    });
+  });
+}
+
+function init() {
+  document.getElementById('addLead').addEventListener('click', addLead);
+  document.getElementById('saveLead').addEventListener('click', saveLead);
+  document.getElementById('cancelEdit').addEventListener('click', () => {
+    document.getElementById('modal').classList.add('hidden');
+  });
+  setupDragAndDrop();
+  render();
+}
+
+document.addEventListener('DOMContentLoaded', init);

--- a/style.css
+++ b/style.css
@@ -1,0 +1,47 @@
+body {
+  font-family: sans-serif;
+  margin: 20px;
+}
+
+#board {
+  display: flex;
+  gap: 1rem;
+}
+
+.column {
+  background: #f0f0f0;
+  padding: 10px;
+  border-radius: 5px;
+  width: 30%;
+}
+
+.lead {
+  background: white;
+  border: 1px solid #ccc;
+  padding: 5px;
+  margin-bottom: 5px;
+  cursor: move;
+}
+
+.hidden {
+  display: none;
+}
+
+#modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modal-content {
+  background: white;
+  padding: 20px;
+  border-radius: 5px;
+}
+


### PR DESCRIPTION
## Summary
- implement lead management board using HTML/CSS/JS
- integrate Aceternity UI via CDN if present
- document how to use the interface

## Testing
- `npm test` *(fails: no package.json)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847d7c70ebc8327bf80905e811e059b